### PR TITLE
Example presets

### DIFF
--- a/ui/frontend/ExampleMenu.tsx
+++ b/ui/frontend/ExampleMenu.tsx
@@ -1,0 +1,48 @@
+import React, { Fragment, useCallback } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+
+import MenuGroup from './MenuGroup';
+import SelectOne from './SelectOne';
+
+import * as actions from './actions';
+import State from './state';
+import { Example } from './types';
+
+interface ExampleMenuProps {
+  close: () => void;
+}
+
+const ExampleMenu: React.SFC<ExampleMenuProps> = props => {
+  const example = useSelector((state: State) => state.configuration.example);
+  const dispatch = useDispatch();
+  const changeExample = useCallback((example) => {
+    dispatch(actions.changeExample(example));
+    props.close();
+  }, [dispatch, props]
+  );
+
+  return (
+    <Fragment>
+      <MenuGroup title="Example &mdash; Choose example code to explore">
+        <SelectOne
+          name="Private Information Retrieval"
+          currentValue={example}
+          thisValue={Example.Pir}
+          changeValue={changeExample}
+        >
+          Explore privately querying a database with our FHE compiler.
+        </SelectOne>
+        <SelectOne
+          name="Sudoku"
+          currentValue={example}
+          thisValue={Example.Sudoku}
+          changeValue={changeExample}
+        >
+          Use our ZKP compiler to prove that you have a valid Sudoku solution, without revealing the solution itself.
+        </SelectOne>
+      </MenuGroup>
+    </Fragment>
+  );
+};
+
+export default ExampleMenu;

--- a/ui/frontend/Header.tsx
+++ b/ui/frontend/Header.tsx
@@ -15,12 +15,15 @@ import * as actions from './actions';
 import * as selectors from './selectors';
 
 import styles from './Header.module.css';
+import ExampleMenu from './ExampleMenu';
+import State from './state';
 
 const Header: React.SFC = () => (
   <div data-test-id="header" className={styles.container}>
     <HeaderSet id="build">
       <SegmentedButtonSet>
         <ExecuteButton />
+        <ExampleMenuButton />
         <BuildMenuButton />
       </SegmentedButtonSet>
     </HeaderSet>
@@ -86,6 +89,20 @@ const BuildMenuButton: React.SFC = () => {
   Button.displayName = 'BuildMenuButton.Button';
 
   return <PopButton Button={Button} Menu={BuildMenu} />;
+};
+
+const ExampleMenuButton: React.SFC = () => {
+  // For now just use enum key as label
+  const label = useSelector((state: State) => state.configuration.example);
+
+  const Button = React.forwardRef<HTMLButtonElement, { toggle: () => void }>(({ toggle }, ref) => (
+    <SegmentedButton title="Example &mdash; Choose the example code" ref={ref} onClick={toggle}>
+      <HeaderButton isExpandable>{label}</HeaderButton>
+    </SegmentedButton>
+  ));
+  Button.displayName = 'ExampleMenuButton.Button';
+
+  return <PopButton Button={Button} Menu={ExampleMenu} />;
 };
 
 const ModeMenuButton: React.SFC = () => {

--- a/ui/frontend/Output/Gist.tsx
+++ b/ui/frontend/Output/Gist.tsx
@@ -15,7 +15,7 @@ const Gist: React.SFC = () => {
 
   return (
     <div>
-      { showLoader ? <Loader /> : <Links />}
+      {showLoader ? <Loader /> : <Links />}
     </div>
   );
 };
@@ -54,16 +54,16 @@ class Copied extends React.PureComponent<CopiedProps, CopiedState> {
 
 const Links: React.SFC = () => {
   const codeUrl = useSelector(selectors.codeUrlSelector);
-  const gistUrl = useSelector((state: State) => state.output.gist.url);
-  const permalink = useSelector(selectors.permalinkSelector);
-  const urloUrl = useSelector(selectors.urloUrlSelector);
+  // const gistUrl = useSelector((state: State) => state.output.gist.url);
+  // const permalink = useSelector(selectors.permalinkSelector);
+  // const urloUrl = useSelector(selectors.urloUrlSelector);
 
   return (
     <Fragment>
-      <Copied href={permalink}>Permalink to the playground</Copied>
-      <Copied href={gistUrl}>Direct link to the gist</Copied>
+      {/*<Copied href={permalink}>Permalink to the playground</Copied>*/}
+      {/*<Copied href={gistUrl}>Direct link to the gist</Copied>*/}
       <Copied href={codeUrl}>Embedded code in link</Copied>
-      <NewWindow href={urloUrl}>Open a new thread in the Rust user forum</NewWindow>
+      {/*<NewWindow href={urloUrl}>Open a new thread in the Rust user forum</NewWindow>*/}
     </Fragment>
   );
 };

--- a/ui/frontend/Router.tsx
+++ b/ui/frontend/Router.tsx
@@ -12,12 +12,13 @@ import * as actions from './actions';
 const homeRoute = new Route('/');
 const helpRoute = new Route('/help');
 
-const stateSelector = ({ page, configuration: { channel, mode, edition } }) => ({
+const stateSelector = ({ page, configuration: { channel, mode, edition, example } }) => ({
   page,
   configuration: {
     channel,
     mode,
     edition,
+    example
   },
 });
 
@@ -34,6 +35,7 @@ const stateToLocation = ({ page, configuration }) => {
         version: configuration.channel,
         mode: configuration.mode,
         edition: configuration.edition,
+        example: configuration.example,
       };
       return {
         pathname: `/?${qs.stringify(query)}`,
@@ -42,7 +44,7 @@ const stateToLocation = ({ page, configuration }) => {
   }
 };
 
-const locationToAction = location => {
+const locationToAction = (location, initialPageLoad: boolean) => {
   const matchedHelp = helpRoute.match(location.pathname);
 
   if (matchedHelp) {
@@ -52,7 +54,9 @@ const locationToAction = location => {
   const matched = homeRoute.match(location.pathname);
 
   if (matched) {
-    return actions.indexPageLoad(qs.parse(location.search.slice(1)));
+    let query = qs.parse(location.search.slice(1));
+    query.initialPageLoad = initialPageLoad;
+    return actions.indexPageLoad(query);
   }
 
   return null;

--- a/ui/frontend/actions.ts
+++ b/ui/frontend/actions.ts
@@ -135,8 +135,8 @@ const setPage = (page: Page) =>
 export const navigateToIndex = () => setPage('index');
 export const navigateToHelp = () => setPage('help');
 
-export const changeExample = (example: Example) =>
-  createAction(ActionType.ChangeExample, { example });
+export const changeExample = (example: Example, changeCode: boolean = true) =>
+  createAction(ActionType.ChangeExample, { example, changeCode });
 
 export const changeEditor = (editor: Editor) =>
   createAction(ActionType.ChangeEditor, { editor });
@@ -758,6 +758,8 @@ function parseEdition(s: string): Edition | null {
 export function indexPageLoad({
   code,
   gist,
+  example,
+  initialPageLoad,
   version = 'stable',
   mode: modeString = 'release',
   edition: editionString,
@@ -782,6 +784,8 @@ export function indexPageLoad({
       dispatch(editCode(code));
     } else if (gist) {
       dispatch(performGistLoad({ id: gist, channel, mode, edition }));
+    } else if (example) {
+      dispatch(changeExample(example, initialPageLoad))
     }
 
     if (channel) {

--- a/ui/frontend/actions.ts
+++ b/ui/frontend/actions.ts
@@ -18,6 +18,7 @@ import {
   DemangleAssembly,
   Edition,
   Editor,
+  Example,
   Focus,
   Mode,
   Notification,
@@ -61,6 +62,7 @@ const createAction = <T extends string, P extends {}>(type: T, props?: P) => (
 
 export enum ActionType {
   SetPage = 'SET_PAGE',
+  ChangeExample = 'CHANGE_EXAMPLE',
   ChangeEditor = 'CHANGE_EDITOR',
   ChangeKeybinding = 'CHANGE_KEYBINDING',
   ChangeAceTheme = 'CHANGE_ACE_THEME',
@@ -132,6 +134,9 @@ const setPage = (page: Page) =>
 
 export const navigateToIndex = () => setPage('index');
 export const navigateToHelp = () => setPage('help');
+
+export const changeExample = (example: Example) =>
+  createAction(ActionType.ChangeExample, { example });
 
 export const changeEditor = (editor: Editor) =>
   createAction(ActionType.ChangeEditor, { editor });
@@ -806,6 +811,7 @@ export function showExample(code): ThunkAction {
 
 export type Action =
   | ReturnType<typeof setPage>
+  | ReturnType<typeof changeExample>
   | ReturnType<typeof changePairCharacters>
   | ReturnType<typeof changeAssemblyFlavor>
   | ReturnType<typeof changeBacktrace>

--- a/ui/frontend/reducers/code.ts
+++ b/ui/frontend/reducers/code.ts
@@ -284,7 +284,11 @@ const exampleMap = {
 export default function code(state = PIR, action: Action): State {
   switch (action.type) {
     case ActionType.ChangeExample:
-      return exampleMap[action.example];
+      if (action.changeCode) {
+        return exampleMap[action.example];
+      } else {
+        return state;
+      }
 
     case ActionType.RequestGistLoad:
       return '';

--- a/ui/frontend/reducers/code.ts
+++ b/ui/frontend/reducers/code.ts
@@ -1,11 +1,11 @@
 import { Action, ActionType } from '../actions';
+import { Example } from '../types';
 
 const HELLO_WORLD: State = `fn main() {
     println!("Hello, world!");
 }`;
 
-const PIR: State = `
-use sunscreen::{
+const PIR: State = `use sunscreen::{
     fhe_program,
     types::{bfv::Signed, Cipher},
     Ciphertext, CompiledFheProgram, Compiler, Error, FheProgramInput, FheRuntime, Params,
@@ -166,12 +166,129 @@ fn main() -> Result<(), Error> {
 }
 `;
 
+const SUDOKU: State = `use sunscreen::{
+    bulletproofs::BulletproofsBackend,
+    types::zkp::{BulletproofsField, NativeField},
+    zkp_program, zkp_var, BackendField, Compiler, Error, ZkpRuntime,
+};
+
+#[zkp_program]
+fn sudoku_proof<F: BackendField>(
+    #[public] board: [[NativeField<F>; 9]; 9],
+    solution: [[NativeField<F>; 9]; 9],
+) {
+    let zero = zkp_var!(0);
+
+    let assert_unique_numbers = |squares| {
+        for i in 1..=9 {
+            let mut circuit = zkp_var!(1);
+            for s in squares {
+                circuit = circuit * (zkp_var!(i) - s);
+            }
+            circuit.constrain_eq(zero);
+        }
+    };
+
+    // Checks rows contain every number from 1 to 9
+    for row in solution {
+        assert_unique_numbers(row);
+    }
+
+    // Checks columns contain each number from 1 to 9
+    for col in 0..9 {
+        let column = solution.map(|r| r[col]);
+        assert_unique_numbers(column);
+    }
+
+    // Checks squares contain each number from 1 to 9
+    for i in 0..3 {
+        for j in 0..3 {
+            let rows = &solution[(i * 3)..(i * 3 + 3)];
+
+            let square = rows.iter().map(|s| &s[(j * 3)..(j * 3 + 3)]);
+
+            let flattened_sq = square
+                .flatten()
+                .copied()
+                .collect::<Vec<_>>()
+                .try_into()
+                .unwrap_or([zero; 9]);
+
+            assert_unique_numbers(flattened_sq);
+        }
+    }
+
+    // Proves that the solution matches up with the puzzle where applicable
+    for i in 0..9 {
+        for j in 0..9 {
+            let square = solution[i][j];
+            let constraint = board[i][j];
+            (constraint * (constraint - square)).constrain_eq(zero);
+        }
+    }
+}
+
+fn main() -> Result<(), Error> {
+    let app = Compiler::new()
+        .zkp_backend::<BulletproofsBackend>()
+        .zkp_program(sudoku_proof)
+        .compile()?;
+
+    let prog = app.get_zkp_program(sudoku_proof).unwrap();
+
+    let runtime = ZkpRuntime::new(&BulletproofsBackend::new())?;
+
+    let ex_board = [
+        [0, 7, 0, 0, 2, 0, 0, 4, 6],
+        [0, 6, 0, 0, 0, 0, 8, 9, 0],
+        [2, 0, 0, 8, 0, 0, 7, 1, 5],
+        [0, 8, 4, 0, 9, 7, 0, 0, 0],
+        [7, 1, 0, 0, 0, 0, 0, 5, 9],
+        [0, 0, 0, 1, 3, 0, 4, 8, 0],
+        [6, 9, 7, 0, 0, 2, 0, 0, 8],
+        [0, 5, 8, 0, 0, 0, 0, 6, 0],
+        [4, 3, 0, 0, 8, 0, 0, 7, 0],
+    ];
+
+    let ex_sol = [
+        [8, 7, 5, 9, 2, 1, 3, 4, 6],
+        [3, 6, 1, 7, 5, 4, 8, 9, 2],
+        [2, 4, 9, 8, 6, 3, 7, 1, 5],
+        [5, 8, 4, 6, 9, 7, 1, 2, 3],
+        [7, 1, 3, 2, 4, 8, 6, 5, 9],
+        [9, 2, 6, 1, 3, 5, 4, 8, 7],
+        [6, 9, 7, 4, 1, 2, 5, 3, 8],
+        [1, 5, 8, 3, 7, 9, 2, 6, 4],
+        [4, 3, 2, 5, 8, 6, 9, 7, 1],
+    ];
+
+    let solution = ex_sol.map(|a| a.map(BulletproofsField::from));
+
+    let board = ex_board.map(|a| a.map(BulletproofsField::from));
+
+    let proof = runtime.prove(prog, vec![], vec![board], vec![solution])?;
+
+    runtime.verify(prog, &proof, vec![], vec![board])?;
+
+    Ok(())
+}
+`;
+
 export type State = string;
+
+const exampleMap = {
+  [Example.Pir]: PIR,
+  [Example.Sudoku]: SUDOKU,
+};
 
 export default function code(state = PIR, action: Action): State {
   switch (action.type) {
+    case ActionType.ChangeExample:
+      return exampleMap[action.example];
+
     case ActionType.RequestGistLoad:
       return '';
+
     case ActionType.GistLoadSucceeded:
       return action.code;
 

--- a/ui/frontend/reducers/code.ts
+++ b/ui/frontend/reducers/code.ts
@@ -1,6 +1,10 @@
 import { Action, ActionType } from '../actions';
 
-const DEFAULT: State = `
+const HELLO_WORLD: State = `fn main() {
+    println!("Hello, world!");
+}`;
+
+const PIR: State = `
 use sunscreen::{
     fhe_program,
     types::{bfv::Signed, Cipher},
@@ -164,7 +168,7 @@ fn main() -> Result<(), Error> {
 
 export type State = string;
 
-export default function code(state = DEFAULT, action: Action): State {
+export default function code(state = PIR, action: Action): State {
   switch (action.type) {
     case ActionType.RequestGistLoad:
       return '';
@@ -175,7 +179,7 @@ export default function code(state = DEFAULT, action: Action): State {
       return action.code;
 
     case ActionType.AddMainFunction:
-      return `${state}\n\n${DEFAULT}`;
+      return `${state}\n\n${HELLO_WORLD}`;
 
     case ActionType.AddImport:
       return action.code + state;

--- a/ui/frontend/reducers/configuration.ts
+++ b/ui/frontend/reducers/configuration.ts
@@ -6,6 +6,7 @@ import {
   DemangleAssembly,
   Edition,
   Editor,
+  Example,
   Mode,
   Orientation,
   PairCharacters,
@@ -15,6 +16,7 @@ import {
 } from '../types';
 
 export interface State {
+  example: Example;
   editor: Editor;
   ace: {
     keybinding: string;
@@ -36,6 +38,7 @@ export interface State {
 }
 
 const DEFAULT: State = {
+  example: Example.Pir,
   editor: Editor.Ace,
   ace: {
     keybinding: 'ace',
@@ -58,11 +61,12 @@ const DEFAULT: State = {
 
 export default function configuration(state = DEFAULT, action: Action): State {
   switch (action.type) {
+    case ActionType.ChangeExample:
+      return { ...state, example: action.example };
     case ActionType.ChangeEditor:
       return { ...state, editor: action.editor };
     case ActionType.ChangeKeybinding: {
       const { ace } = state;
-
       return { ...state, ace: { ...ace, keybinding: action.keybinding } };
     }
     case ActionType.ChangeAceTheme: {

--- a/ui/frontend/types.ts
+++ b/ui/frontend/types.ts
@@ -1,3 +1,8 @@
+export enum Example {
+  Pir = 'pir',
+  Sudoku = 'sudoku',
+}
+
 export type Page = 'index' | 'help';
 
 export interface Position {

--- a/ui/frontend/uss-router/index.ts
+++ b/ui/frontend/uss-router/index.ts
@@ -9,6 +9,7 @@ export function createRouter({
   stateToLocation,
   locationToAction,
 }) {
+  let initialPageLoad = true; // Avoid clobbering user changes
   let doingUpdateFromBrowser = false; // Avoid immediately PUSHing the state again
   let interestingPrevState;
 
@@ -29,11 +30,12 @@ export function createRouter({
   });
 
   const dispatchBrowserLocationChange = nextLocation => {
-    const action = locationToAction(nextLocation);
+    const action = locationToAction(nextLocation, initialPageLoad);
     if (action) {
       doingUpdateFromBrowser = true;
       store.dispatch(action);
       doingUpdateFromBrowser = false;
+      initialPageLoad = false;
     }
   };
 


### PR DESCRIPTION
The PIR FHE example is still the default, but now the user can choose other examples (currently just PIR FHE and Sudoku ZKP). You can also link to an example, e.g. `playground.sunscreen.tech/?example=sudoku`.

Also, take a look at the explanation in [this commit msg](https://github.com/Sunscreen-tech/rust-playground/commit/dfff10981dda453cfd54df9547436ffd80979efb). One unfortunate side effect is that if you have navigated to a particular example (or followed a link with an example set), so that `&example=_` is present in the URL, refreshing your browser will now refresh the example code. Previously local storage would take precedent. But I don't see a great way around that...

# screenshots

![2023-07-11-122208_2256x1324_scrot](https://github.com/Sunscreen-tech/rust-playground/assets/7246591/27e3f9af-18ad-4a7c-8de9-164a23e548e7)
![2023-07-11-122302_2256x1328_scrot](https://github.com/Sunscreen-tech/rust-playground/assets/7246591/a1a6ba2f-0354-48ee-b897-878ec847206a)
